### PR TITLE
Add --no-resources option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Which will produce:
 | **cordova_prepare**      | Specifies whether to run `ionic cordova prepare` before building  | CORDOVA_PREPARE               |  *true*   |
 | **min_sdk_version**      | Overrides the value of minSdkVersion set in `AndroidManifest.xml` | CORDOVA_ANDROID_MIN_SDK_VERSION   | ''       |
 | **cordova_no_fetch**      | Specifies whether to run `ionic cordova platform add` with `--nofetch` parameter  | CORDOVA_NO_FETCH               |  *false*   |
+| **cordova_no_resources** | Specifies whether to run `ionic cordova platform add` with `--no-resources` parameter  | CORDOVA_NO_RESOURCES               |  *false*   |
 | **build_flag**           | An array of Xcode buildFlag. Will be appended on compile command.  | CORDOVA_IOS_BUILD_FLAG               | [] |
 | **cordova_build_config_file**      | Call `ionic cordova compile` with `--buildConfig=<ConfigFile>` to specify build config file path  | CORDOVA_BUILD_CONFIG_FILE               |     |
 

--- a/lib/fastlane/plugin/ionic/actions/ionic_action.rb
+++ b/lib/fastlane/plugin/ionic/actions/ionic_action.rb
@@ -79,12 +79,11 @@ module Fastlane
       # add platform if missing (run step #1)
       def self.check_platform(params)
         platform = params[:platform]
+        args = []
+        args << '--nofetch' if params[:cordova_no_fetch]
+        args << '--no-resources' if params[:cordova_no_resources]
         if platform && !File.directory?("./platforms/#{platform}")
-          if params[:cordova_no_fetch]
-            sh "ionic cordova platform add #{platform} --no-interactive --nofetch"
-          else
-            sh "ionic cordova platform add #{platform} --no-interactive"
-          end
+          sh "ionic cordova platform add #{platform} --no-interactive #{args.join(' ')}"
         end
       end
 
@@ -288,6 +287,13 @@ module Fastlane
             key: :cordova_no_fetch,
             env_name: "CORDOVA_NO_FETCH",
             description: "Call `cordova platform add` with `--nofetch` parameter",
+            default_value: false,
+            is_string: false
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :cordova_no_resources,
+            env_name: "CORDOVA_NO_RESOURCES",
+            description: "Call `cordova platform add` with `--no-resources` parameter",
             default_value: false,
             is_string: false
           ),


### PR DESCRIPTION
PR for #46 

I need this option because the `cordova platform add` command fails (same like #45).